### PR TITLE
fix memory leak

### DIFF
--- a/02_Keypad_and_GUI_Timer/keypad_app/keypad_app.c
+++ b/02_Keypad_and_GUI_Timer/keypad_app/keypad_app.c
@@ -17,8 +17,7 @@
 #include <notification/notification_messages.h>
 
 // (*1) This will be the label that tells you which keypad-button is pressed.
-char* currentKeyPressed;
-int BUFFER = 10;
+char* currentKeyPressed = "NONE";
 
 static void draw_callback(Canvas* canvas, void* ctx) {
     UNUSED(ctx);
@@ -52,9 +51,6 @@ static void input_callback(InputEvent* input_event, void* ctx) {
 
 int32_t main_fap(void* p) {
     UNUSED(p);
-    // Initialization of (*1)
-    currentKeyPressed = (char*)malloc(sizeof(char) * BUFFER);
-    currentKeyPressed = "NONE";
 
     InputEvent event;
     FuriMessageQueue* event_queue = furi_message_queue_alloc(8, sizeof(InputEvent));


### PR DESCRIPTION
Spotted this issue while working through the examples. The buffer created with malloc dosen't do anything as the pointer that malloc returns on line 56 is instantly overwriten on line 57.

To explain, when you write something like this:

``` C
char* str = "hello";
```
str will contain a pointer to the start of the string "hello" that lives in read only memory.