### PR TITLE
add viewport update on example  "02_Keypad_and_GUI_Timer"

### DIFF
--- a/02_Keypad_and_GUI_Timer/keypad_app/keypad_app.c
+++ b/02_Keypad_and_GUI_Timer/keypad_app/keypad_app.c
@@ -92,6 +92,8 @@ int32_t main_fap(void* p) {
         if(event.key == InputKeyBack) {
             break;
         }
+        // Update the screen
+        view_port_update(view_port);
     }
 
     // When you use the timer, remember to stop the timer


### PR DESCRIPTION
Hello,

First of all thank you very much for your work. I am currently reading your examples and finding them immensely helpful!

I think I spotted a tiny oversight in example `02_Keypad_and_GUI_Timer`. The view port update is not triggered, therefore the key actually pressed is never displayed. This pull request adds it back !